### PR TITLE
enable local file access to wkhtmltopdf

### DIFF
--- a/build/lib/docme/output_formats.py
+++ b/build/lib/docme/output_formats.py
@@ -32,6 +32,7 @@ class PdfFormat(OutputFormat):
             'footer-line': '',
             'footer-font-size': '7',
             '--footer-right': 'right footer',
+            'enable-local-file-access': None,
 
             'custom-header': [
                 ('Accept-Encoding', 'gzip')


### PR DESCRIPTION
the new versions of wkhtmltopdf block the access to local files by default